### PR TITLE
Temporarily restrict SQLAlchemy version <1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,20 +24,19 @@ python_requires = >=3.7
 install_requires =
     aiohttp>=3.7.2,<4.0.0
     backports.zoneinfo;python_version<"3.9"
-    clickhouse_sqlalchemy>=0.1.5
+    clickhouse_sqlalchemy>=0.1.5,<0.2.0
     lark-parser>=0.11.2
     simplejson>=3.16.0
-    sqlalchemy>=1.3.0
+    sqlalchemy>=1.3.0,<1.4.0
 setup_requires =
     setuptools_scm>=3.3.3
 
 [options.extras_require]
-test =
-    lovely-pytest-docker>=0.1.0
+dev =
+    lovely-pytest-docker>=0.3.0
     pytest>=6.2.0
-    pytest-asyncio>=0.14.0
+    pytest-asyncio>=0.17.0
     pytest-cov>=2.11.1
-    six # Required by lovely-pytest-docker, but not included in its deps
 
 [options.package_data]
 aiochsa =
@@ -49,6 +48,7 @@ aiochsa =
 testpaths = tests
 addopts = --strict-markers -r aP --tb=native
 filterwarnings = error
+asyncio_mode = auto
 
 [coverage:run]
 branch = True
@@ -72,7 +72,7 @@ warn_unused_ignores = True
 envlist = py{37,38,39,310},ch{19_16,20_3,20_8,21_1,21_3,21_8},mypy
 
 [testenv]
-extras = test
+extras = dev
 passenv = CLICKHOUSE_VERSION
 commands = pytest {posargs:--cov --cov-report=}
 
@@ -100,6 +100,6 @@ setenv = CLICKHOUSE_VERSION = 21.8.13.6
 
 [testenv:mypy]
 basepython = python3.10
-extras = test
+extras = dev
 deps = mypy>=0.910
 commands = mypy --install-types --non-interactive -p aiochsa -p tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime
 from decimal import Decimal
 import os
@@ -10,12 +9,6 @@ import sqlalchemy as sa
 import aiochsa
 from aiochsa import error_codes
 from aiochsa.dialect import ClickhouseSaDialect
-
-
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if asyncio.iscoroutinefunction(item.function):
-            item.add_marker('asyncio')
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
clickhouse-sqlalchemy 0.2.0 is out with SQLAlchemy 1.4 support, but it breaks aiochsa. SQLAlchemy internals changed a lot, so it's would be good to created intermediate release with older versions pinned. 